### PR TITLE
Fix builds for older version of libprotobuf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build/
+.vscode/

--- a/examples/libfuzzer/libfuzzer_bin_example.cc
+++ b/examples/libfuzzer/libfuzzer_bin_example.cc
@@ -55,7 +55,7 @@ DEFINE_BINARY_PROTO_FUZZER(const libfuzzer_example::Msg& message) {
       !std::isnan(message.optional_float()) &&
       std::fabs(message.optional_float()) > 1000 &&
       message.any().UnpackTo(&file) && !file.name().empty()) {
-    std::cerr << absl::StrCat(message) << "\n";
+    std::cerr << message.DebugString() << "\n";
     abort();
   }
 }

--- a/examples/libfuzzer/libfuzzer_example.cc
+++ b/examples/libfuzzer/libfuzzer_example.cc
@@ -55,7 +55,7 @@ DEFINE_PROTO_FUZZER(const libfuzzer_example::Msg& message) {
       !std::isnan(message.optional_float()) &&
       std::fabs(message.optional_float()) > 1000 &&
       message.any().UnpackTo(&file) && !file.name().empty()) {
-    std::cerr << absl::StrCat(message) << "\n";
+    std::cerr << message.DebugString() << "\n";
     abort();
   }
 }

--- a/src/field_instance.h
+++ b/src/field_instance.h
@@ -190,6 +190,21 @@ class ConstFieldInstance {
     return descriptor_->message_type();
   }
 
+#if PROTOBUF_VERSION < 3019006
+  bool EnforceUtf8() const {
+    return descriptor_->type() == protobuf::FieldDescriptor::TYPE_STRING &&
+           descriptor()->file()->syntax() ==
+               protobuf::FileDescriptor::SYNTAX_PROTO3;
+  }
+
+  const protobuf::FieldDescriptor* descriptor() const { return descriptor_; }
+
+  std::string DebugString() const {
+    std::string s = descriptor_->DebugString();
+    if (is_repeated()) s += "[" + std::to_string(index_) + "]";
+    return s + " of\n" + message_->DebugString();
+  }
+#else
   bool EnforceUtf8() const { return descriptor_->requires_utf8_validation(); }
 
   const protobuf::FieldDescriptor* descriptor() const { return descriptor_; }
@@ -199,6 +214,7 @@ class ConstFieldInstance {
     if (is_repeated()) s += absl::StrCat("[", index_, "]");
     return s + " of\n" + absl::StrCat(*message_);
   }
+#endif
 
  protected:
   bool is_repeated() const { return descriptor_->is_repeated(); }

--- a/src/mutator.cc
+++ b/src/mutator.cc
@@ -801,7 +801,7 @@ std::string Mutator::MutateUtf8String(const std::string& value,
 
 bool Mutator::IsInitialized(const Message& message) const {
   if (!keep_initialized_ || message.IsInitialized()) return true;
-  std::cerr << "Uninitialized: " << absl::StrCat(message) << "\n";
+  std::cerr << "Uninitialized: " << message.DebugString() << "\n";
   return false;
 }
 

--- a/src/mutator_test.cc
+++ b/src/mutator_test.cc
@@ -410,8 +410,8 @@ bool Mutate(const protobuf::Message& from, const protobuf::Message& to,
   }
 
   ADD_FAILURE() << "Failed to get from:\n"
-                << absl::StrCat(from) << "\nto:\n"
-                << absl::StrCat(to);
+                << from.DebugString() << "\nto:\n"
+                << to.DebugString();
   return false;
 }
 


### PR DESCRIPTION
- The following [upstream commit in protobuf ](https://github.com/protocolbuffers/protobuf/commit/d85c9944c55fb38f4eae149979a0f680ea125ecb) added `MessageDescriptor.requires_utf8_validation`
- Versions preceeding this protobuf version are still being used in some repos, e.g. fedora
- Adds macro to revert to 1.1 logic in this case
- Reverts https://github.com/google/libprotobuf-mutator/pull/243